### PR TITLE
Execute of show chosen command (issue #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ around the editor (and for others wanting to scratch the occasional
 I've-been-using-vim-for-years-but-forgot-how-to-scroll-horizontally itch).
 Disable it with `let g:cheatsheet_use_default = v:false`.
 
-| Telescope mappings | Description                                                      |
-| ---                | ---                                                              |
-| `<C-E>`            | Edit user cheatsheet à la `:CheatsheetEdit`                      |
-| `<C-D>`            | Toggle `g:cheatsheet_use_default`                                |
-| `Enter`            | Execute command if possible, otherwise print for easy reference. |
+| Telescope mappings | Description                                                                        |
+| ---                | ---                                                                                |
+| `<C-E>`            | Edit user cheatsheet à la `:CheatsheetEdit`                                        |
+| `<C-D>`            | Toggle `g:cheatsheet_use_default`                                                  |
+| `Enter`            | Fill in the command on de commandline. If not a command, print for easy reference. |
 
 Since `cheatsheet.nvim` provides it's own commands,  it is not required to
 "load" `cheatsheet.nvim` with Telescope which is usually required for plugins

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ around the editor (and for others wanting to scratch the occasional
 I've-been-using-vim-for-years-but-forgot-how-to-scroll-horizontally itch).
 Disable it with `let g:cheatsheet_use_default = v:false`.
 
-| Telescope mappings | Description                                 |
-| ---                | ---                                         |
-| `<C-E>`            | Edit user cheatsheet à la `:CheatsheetEdit` |
-| `<C-D>`            | Toggle `g:cheatsheet_use_default`           |
-| `Enter`            | Close the Telescope window                  |
+| Telescope mappings | Description                                                      |
+| ---                | ---                                                              |
+| `<C-E>`            | Edit user cheatsheet à la `:CheatsheetEdit`                      |
+| `<C-D>`            | Toggle `g:cheatsheet_use_default`                                |
+| `Enter`            | Execute command if possible, otherwise print for easy reference. |
 
 Since `cheatsheet.nvim` provides it's own commands,  it is not required to
 "load" `cheatsheet.nvim` with Telescope which is usually required for plugins

--- a/lua/cheatsheet/telescope.lua
+++ b/lua/cheatsheet/telescope.lua
@@ -82,29 +82,36 @@ M.pick_cheat = function(opts)
                 actions.select_default:replace(
                     function()
                         local selection = actions_state.get_selected_entry()
-						local cheat = selection.value.cheatcode
-						local description = selection.value.description
+                        local cheat = selection.value.cheatcode
+                        local description = selection.value.description
 
                         actions.close(prompt_bufnr)
 
-						if string.len(cheat) > 1 then
-							-- check for valid command
+                        if string.len(cheat) > 1 then
+                            -- check for valid command
 
-							cheat = cheat:match("^%s*(.-)%s*$") -- strip spaces
-							if cheat:match("^:%w+$") ~= nil then
-								-- execute command, previous match should already
-								-- sanitize input
-								vim.cmd(cheat)
-							else
-								-- otherwise show command
-								print("Cheatsheet: Press",
-									cheat,
-									"to",
-									description:lower())
-							end
-						else
-							print("Cheatsheet: No command could be executed")
-						end
+                            cheat = cheat:match("^%s*(.-)%s*$") -- strip spaces
+                            local regex = "^:[%w ]+"
+                            local cheat_sanitized = cheat:match(regex)
+                            if cheat_sanitized ~= nil then
+                                -- execute command, previous match should already
+                                -- sanitize input and next should stop at next
+                                -- non normal character like [<>,]
+                                -- Regex might need an update in the future
+                                vim.api.nvim_feedkeys(
+                                    vim.api.nvim_replace_termcodes(
+                                        cheat_sanitized, true, false, true),
+                                    "t", true)
+                            else
+                                -- otherwise show command
+                                print("Cheatsheet: Press",
+                                    cheat,
+                                    "to",
+                                    description:lower())
+                            end
+                        else
+                            print("Cheatsheet: No command could be executed")
+                        end
                     end
                 )
                 map(

--- a/lua/cheatsheet/telescope.lua
+++ b/lua/cheatsheet/telescope.lua
@@ -82,35 +82,34 @@ M.pick_cheat = function(opts)
                 actions.select_default:replace(
                     function()
                         local selection = actions_state.get_selected_entry()
-                        local cheat = selection.value.cheatcode
+                        local section = selection.value.section
                         local description = selection.value.description
+                        local cheat = selection.value.cheatcode
 
                         actions.close(prompt_bufnr)
 
-                        if string.len(cheat) > 1 then
-                            -- check for valid command
-
-                            cheat = cheat:match("^%s*(.-)%s*$") -- strip spaces
-                            local regex = "^:[%w ]+"
-                            local cheat_sanitized = cheat:match(regex)
-                            if cheat_sanitized ~= nil then
-                                -- execute command, previous match should already
-                                -- sanitize input and next should stop at next
-                                -- non normal character like [<>,]
-                                -- Regex might need an update in the future
-                                vim.api.nvim_feedkeys(
-                                    vim.api.nvim_replace_termcodes(
-                                        cheat_sanitized, true, false, true),
-                                    "t", true)
-                            else
-                                -- otherwise show command
-                                print("Cheatsheet: Press",
-                                    cheat,
-                                    "to",
-                                    description:lower())
-                            end
-                        else
+                        if string.len(cheat) == 1 then
                             print("Cheatsheet: No command could be executed")
+                            return
+                        end
+
+                        -- check for valid command
+                        local cheat_sanitized = cheat:match("^:[%w ]+")
+                        if cheat_sanitized ~= nil then
+                            -- execute command, previous match should already
+                            -- sanitize input and next should stop at next
+                            -- non normal character like [<>,]
+                            -- Regex might need an update in the future
+                            vim.api.nvim_feedkeys(
+                                vim.api.nvim_replace_termcodes(
+                                    cheat_sanitized, true, false, true),
+                                "n", true)
+                        else
+                            -- otherwise show command
+                            print("Cheatsheet ["..section.."]: Press",
+                                cheat,
+                                "to",
+                                description:lower())
                         end
                     end
                 )

--- a/lua/cheatsheet/telescope.lua
+++ b/lua/cheatsheet/telescope.lua
@@ -1,4 +1,5 @@
 local actions = require('telescope.actions')
+local actions_state = require('telescope.actions.state')
 local finders = require('telescope.finders')
 local pickers = require('telescope.pickers')
 
@@ -80,9 +81,30 @@ M.pick_cheat = function(opts)
             attach_mappings = function(prompt_bufnr, map)
                 actions.select_default:replace(
                     function()
-                        -- local selection = action_state.get_selected_entry()
-                        -- close telescope on Enter
+                        local selection = actions_state.get_selected_entry()
+						local cheat = selection.value.cheatcode
+						local description = selection.value.description
+
                         actions.close(prompt_bufnr)
+
+						if string.len(cheat) > 1 then
+							-- check for valid command
+
+							cheat = cheat:match("^%s*(.-)%s*$") -- strip spaces
+							if cheat:match("^:%w+$") ~= nil then
+								-- execute command, previous match should already
+								-- sanitize input
+								vim.cmd(cheat)
+							else
+								-- otherwise show command
+								print("Cheatsheet: Press",
+									cheat,
+									"to",
+									description:lower())
+							end
+						else
+							print("Cheatsheet: No command could be executed")
+						end
                     end
                 )
                 map(


### PR DESCRIPTION
This is the pullrequest from issue #2.

I changed the vim.cmd to vim.api.nvim_feedkeys with some extra sanitization.

Maybe something noteworthy is that on the latest nightly (0.5.0+dev+1372+g056c464e8-1), the telescope window stoped working after trying to execute a command (probably a regression in neovim). For me it worked on an older version (0.5.0+dev+1227+gb518b9076-1).

Hope you like it :smiley: