### PR TITLE
Allow users to configure the loading of runtimepath cheatsheets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ This is the default configuration:
 
 ```lua
 require("cheatsheet").setup({
+    -- Whether to show rtp cheatsheets
+    rtp_cheatsheets = true,
+
     -- Whether to show bundled cheatsheets
 
     -- For generic cheatsheets like default, unicode, nerd-fonts, etc

--- a/lua/cheatsheet/config.lua
+++ b/lua/cheatsheet/config.lua
@@ -3,6 +3,9 @@ local M = {}
 -- NOTE: Watch out for bugs in cheatsheet.get_cheatsheet_files if
 -- defaults is modified in the future
 local defaults = {
+    -- Whether to show rtp cheatsheets
+    rtp_cheatsheets = true,
+
     -- Whether to show bundled cheatsheets
 
     -- For generic cheatsheets like default, unicode, nerd-fonts, etc

--- a/lua/cheatsheet/init.lua
+++ b/lua/cheatsheet/init.lua
@@ -8,8 +8,9 @@ local M = {}
 
 M.setup = function(opts) config.setup(opts) end
 
--- Get `cheatsheet.txt` files from any directory in runtimepath
--- Inlcudes bundled cheatsheets if configured to do so.
+-- Includes the user's `cheatsheet.txt` file.
+-- Includes `cheatsheet.txt` files from any directory in runtimepath if configured to do so.
+-- Includes bundled cheatsheets if configured to do so.
 -- @param *opts* config.options like table
 -- @return array of filepaths
 M.get_cheatsheet_files = function(opts)
@@ -37,14 +38,14 @@ M.get_cheatsheet_files = function(opts)
             cheatsheet_plugin_name_pat, plugin_include
     )
 
-    -- Load user's cheatsheet.
+    -- Includes user's cheatsheet.
     local cheats = { utils.get_user_cheatsheet() }
 
-    -- Load rtp cheatsheets (if configured to do so).
+    -- Includes rtp cheatsheets (if configured to do so).
     local rtp_cheatsheets = vim.api.nvim_get_runtime_file("cheatsheet.txt", true)
     filter_insert(cheats, rtp_cheatsheets, cheatsheet_name_pat, opts.rtp_cheatsheets)
 
-    -- Load bundled cheatsheets (if configured to do so).
+    -- Includes bundled cheatsheets (if configured to do so).
     local bundled_cheatsheets = utils.get_bundled_cheatsheets()
     filter_insert(cheats, bundled_cheatsheets, cheatsheet_name_pat, opts.bundled_cheatsheets)
 

--- a/lua/cheatsheet/init.lua
+++ b/lua/cheatsheet/init.lua
@@ -37,9 +37,16 @@ M.get_cheatsheet_files = function(opts)
             cheatsheet_plugin_name_pat, plugin_include
     )
 
-    local cheats = vim.api.nvim_get_runtime_file("cheatsheet.txt", true)
-    local bundled = utils.get_bundled_cheatsheets()
-    filter_insert(cheats, bundled, cheatsheet_name_pat, opts.bundled_cheatsheets)
+    -- Load user's cheatsheet.
+    local cheats = { utils.get_user_cheatsheet() }
+
+    -- Load rtp cheatsheets (if configured to do so).
+    local rtp_cheatsheets = vim.api.nvim_get_runtime_file("cheatsheet.txt", true)
+    filter_insert(cheats, rtp_cheatsheets, cheatsheet_name_pat, opts.rtp_cheatsheets)
+
+    -- Load bundled cheatsheets (if configured to do so).
+    local bundled_cheatsheets = utils.get_bundled_cheatsheets()
+    filter_insert(cheats, bundled_cheatsheets, cheatsheet_name_pat, opts.bundled_cheatsheets)
 
     filter_insert(
         cheats, bundled_plugins, cheatsheet_plugin_name_pat,


### PR DESCRIPTION
* The user's cheatsheet loads unconditionally.
* `rtp_cheatsheets` configuration defaults to previous behavior.