### PR TITLE
Markdown cheat sheet improvements

### DIFF
--- a/cheatsheets/cheatsheet-markdown.txt
+++ b/cheatsheets/cheatsheet-markdown.txt
@@ -5,10 +5,11 @@ Horizontal rule              | ---
 Line break <br>              | Two spaces at line end
 Section link to 'My Heading' | [text](#my-heading)
 Bold text                    | **bold text**
-Italic text                  | *italicized text*
+Italic text                  | *italic text*
 Blockquote                   | > blockquote
 Ordered list                 | 1. First item
 Unordered list               | - First item
-Code                         | `some code` or <code>some code</code>
-Open fenced code block       | ```[language] ()e.g. ```shell or ```python)
+Inline code (tick)           | `some code`
+Inline code (code tag)       | <code>some code</code>
+Open fenced code block       | ```[language] (e.g. ```shell or ```python)
 Close fenced code block      | ```

--- a/cheatsheets/cheatsheet-markdown.txt
+++ b/cheatsheets/cheatsheet-markdown.txt
@@ -1,6 +1,14 @@
 ## markdown
 Links                        | [text in for link](http://example.com)
-Images                       | [alt text](http://example.com/image.png "image title")
+Images                       | ![alt text](http://example.com/image.png "image title")
 Horizontal rule              | ---
 Line break <br>              | Two spaces at line end
-Section link to # My Heading | [text](#my-heading)
+Section link to 'My Heading' | [text](#my-heading)
+Bold text                    | **bold text**
+Italic text                  | *italicized text*
+Blockquote                   | > blockquote
+Ordered list                 | 1. First item
+Unordered list               | - First item
+Code                         | `some code` or <code>some code</code>
+Open fenced code block       | ```[language] ()e.g. ```shell or ```python)
+Close fenced code block      | ```


### PR DESCRIPTION
This PR adds a few more cheats to the Markdown cheat sheet. Cheats were added for bold text, italic text, code blocks, blockquote, and a few others. In addition to these new markdown cheats, a couple of changes were made to existing cheats. An exclamation point was added to the image markdown and the # character was replaced with single quotes as it was being recognized as a comment character.

I'm new to this project and just started using it. Pretty nice! But I do not yet understand how to do some of the cheats markdown would have. Like how to do multi-line cheats for something like lists or code blocks. For this PR I reduced any cheat with multiple lines down to a single line. Anyway, it's a start.